### PR TITLE
Fix player ship orientation and arrow position

### DIFF
--- a/game.py
+++ b/game.py
@@ -59,7 +59,7 @@ while running:
     # 6.1 - Set player position and rotation
     position = pygame.mouse.get_pos()
     angle = math.atan2(position[1]-(playerpos[1]+32),position[0]-(playerpos[0]+26))
-    playerrot = pygame.transform.rotate(player, 360-angle*57)
+    playerrot = pygame.transform.rotate(player, 90-angle*57)
     playerpos1 = (playerpos[0]-playerrot.get_rect().width/2, playerpos[1]-playerrot.get_rect().height/2)
     screen.blit(playerrot, playerpos1)
     # 6.2 - Draw arrows

--- a/game.py
+++ b/game.py
@@ -153,7 +153,7 @@ while running:
             #shoot.play()
             position = pygame.mouse.get_pos()
             acc[1] += 1
-            arrows.append([math.atan2(position[1]-(playerpos1[1]+32),position[0]-(playerpos1[0]+26)),playerpos1[0]+32,playerpos1[1]+32])
+            arrows.append([math.atan2(position[1]-(playerpos1[1]+64),position[0]-(playerpos1[0]+64)),playerpos1[0]+64,playerpos1[1]+64])
     # 9 - Move player
     if keys[0]:
         playerpos[1] -= 5

--- a/step4.md
+++ b/step4.md
@@ -16,7 +16,7 @@ Then, replace the last line in section #6 (the player.blit line) with the follow
     # 6.1 - Set player position and rotation
     position = pygame.mouse.get_pos()
     angle = math.atan2(position[1]-(playerpos[1]+32),position[0]-(playerpos[0]+26))
-    playerrot = pygame.transform.rotate(player, 360-angle*57.29)
+    playerrot = pygame.transform.rotate(player, 90-angle*57.29)
     playerpos1 = (playerpos[0]-playerrot.get_rect().width/2, playerpos[1]-playerrot.get_rect().height/2)
     screen.blit(playerrot, playerpos1)
 ```

--- a/step5.md
+++ b/step5.md
@@ -25,7 +25,7 @@ Now when a user clicks the mouse, an arrow needs to fire. Add the following to t
         if event.type==pygame.MOUSEBUTTONDOWN:
             position=pygame.mouse.get_pos()
             acc[1]+=1
-            arrows.append([math.atan2(position[1]-(playerpos1[1]+32),position[0]-(playerpos1[0]+26)),playerpos1[0]+32,playerpos1[1]+32])
+            arrows.append([math.atan2(position[1]-(playerpos1[1]+64),position[0]-(playerpos1[0]+64)),playerpos1[0]+64,playerpos1[1]+64])
 ```
 
 This code checks if the mouse was clicked and if it was, it gets the mouse position and calculates the arrow rotation based on the rotated player position and the cursor position. This rotation value is stored in the arrows array.


### PR DESCRIPTION
This PR addresses 2 issues:

1. The player ship now points directly towards the mouse pointer instead of 90 degrees to the side of it.
2. Arrows now originate from the center of the ship instead of the top-left.

Changes have been made to both the `game.py` file and the corresponding step files.